### PR TITLE
performance issue - possible solution

### DIFF
--- a/jquery.qubit.js
+++ b/jquery.qubit.js
@@ -12,7 +12,7 @@
         self.process(e.target);
       }
     });
-    this.scope.find('input[type=checkbox]:checked').each(function() {
+    this.scope.children("li").children('input[type=checkbox]:checked').each(function() {
       self.process(this);
     });
   };


### PR DESCRIPTION
Hi,

i had terrible performance issues using jquery-bonsai with jquery-qubit. In my scenario I build a relativly big and deep (20 root-nodes, up to 4 levels) bonsai with checkboxes and qubit for indeterminate states. 
It took approximatly 2sec to render that bonsai. Qubits part took 1.5sec. 
With that "fix" the render time is down to 400ms, where qubit only takes 150ms. 

The main problem seems to be, that you walk the tree down and up for _every_ node, where you only need the root-nodes aka the first child level. I know that this solution isn't generally applyable and only works with bonsai. Bonsai seems to wrap all <li> in an <div>, so qubit gets this <div>. In other cases you may not have this wrapper, my selector may be wrong. But it should give you a general idea of the problem.

thx