### PR TITLE
Add npm package and allow AMD/CommonJS loading

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-qubit",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "homepage": "https://github.com/aexmachina/jquery-qubit",
   "authors": [
     "aexmachina"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-qubit",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "homepage": "https://github.com/aexmachina/jquery-qubit",
   "authors": [
     "aexmachina"

--- a/jquery.qubit.js
+++ b/jquery.qubit.js
@@ -1,4 +1,12 @@
-(function($) {
+(function(factory){
+  if (typeof define === 'function' && define.amd) {
+    define(['jquery'], factory);
+  } else if (typeof exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    factory(jQuery);
+  }
+}(function($) {
   $.fn.qubit = function(options) {
     return this.each(function() {
       new Qubit(this, options);
@@ -90,4 +98,4 @@
       }
     }
   };
-}(jQuery));
+}));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "jquery-qubit",
+  "version": "2.0.6",
+  "description": "Provides the semantics for a nested list of tri-state checkboxes, using the HTML5 \"indeterminate\" property",
+  "main": "jquery.qubit.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "jquery": "*"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aexmachina/jquery-qubit.git"
+  },
+  "keywords": ["jquery", "checkbox", "indeterminate"],
+  "authors": ["aexmachina"],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/aexmachina/jquery-qubit/issues"
+  },
+  "homepage": "https://github.com/aexmachina/jquery-qubit#readme"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-qubit",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Provides the semantics for a nested list of tri-state checkboxes, using the HTML5 \"indeterminate\" property",
   "main": "jquery.qubit.js",
   "scripts": {
@@ -13,8 +13,14 @@
     "type": "git",
     "url": "git+https://github.com/aexmachina/jquery-qubit.git"
   },
-  "keywords": ["jquery", "checkbox", "indeterminate"],
-  "authors": ["aexmachina"],
+  "keywords": [
+    "jquery",
+    "checkbox",
+    "indeterminate"
+  ],
+  "authors": [
+    "aexmachina"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/aexmachina/jquery-qubit/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-qubit",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Provides the semantics for a nested list of tri-state checkboxes, using the HTML5 \"indeterminate\" property",
   "main": "jquery.qubit.js",
   "scripts": {


### PR DESCRIPTION
Might bother you to make a simple test since I don't have latest version running in an application, just followed common pattern. I'll create PR on bonsai too once this one ok - aka bonsai would be better to have dependency expressed as qubit in package.